### PR TITLE
refactor(README.md): way of calling dispatchEvents function is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ use App\Rabbitmq\Rabbit\Client;
 use PhpAmqpLib\Message\AMQPMessage;
     
 $client = app(Client::class);
-$client->consume('queue-one', function (AMQPMessage $message) {
+$client->consume('queue-one', function (AMQPMessage $message) use ($client) {
             /**
              * Acknowledge a message
              */
@@ -43,7 +43,7 @@ $client->consume('queue-one', function (AMQPMessage $message) {
             /**
              * @var Client $this
              */
-            $this->dispatchEvents($message);
+            $client->dispatchEvents($message);
         })->wait(); // or waitForever();
 
 ?>


### PR DESCRIPTION
The project will not use this line anymore but someone still use $this->dispatchEvents function so i  have not delete this line.

![image](https://github.com/sobirjonovs/laravel-rabbit/assets/63544323/4156f6a1-8af8-4884-8da5-a4b36bf02a86)
