### PR TITLE
When error is out in service, the messages will be sent to dead-letter-queue

### DIFF
--- a/src/Exceptions/DeadLetterHandler.php
+++ b/src/Exceptions/DeadLetterHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Rabbitmq\Exceptions;
+
+use App\Rabbitmq\Rabbit\Client;
+use Throwable;
+
+class DeadLetterHandler
+{
+    /**
+     * When error is happened, the function sends message to dead letter queue
+     *
+     * @param array $data
+     * @param Throwable $exception
+     * @param Client $client
+     * @throws \Exception
+     */
+    public static function toQueue(array $data, Throwable $exception, Client $client): void
+    {
+        $data['error'] = [
+            'file' => $exception->getFile(),
+            'line' => $exception->getLine(),
+            'message' => $exception->getMessage(),
+            'time' => date('Y-m-d H:i:s'),
+        ];
+
+        $client->setMessage($data)->publish(config('amqp.dead_letter_queue'));
+    }
+}

--- a/src/Exceptions/DeadLetterHandler.php
+++ b/src/Exceptions/DeadLetterHandler.php
@@ -15,7 +15,7 @@ class DeadLetterHandler
      * @param Client $client
      * @throws \Exception
      */
-    public static function toQueue(array $data, Throwable $exception, Client $client): void
+    public function toQueue(array $data, Throwable $exception, Client $client): void
     {
         $data['error'] = [
             'file' => $exception->getFile(),

--- a/src/Rabbit/Client.php
+++ b/src/Rabbit/Client.php
@@ -2,6 +2,7 @@
 
 namespace App\Rabbitmq\Rabbit;
 
+use App\Rabbitmq\Exceptions\DeadLetterHandler;
 use Closure;
 use Rabbitmq;
 use Exception;
@@ -123,6 +124,8 @@ class Client implements RabbitContract
     {
         $this->connection = $client;
         $this->channel = $this->connection->channel();
+
+        $this->queueDeclare(config('amqp.dead_letter_queue'));
     }
 
     /**
@@ -299,7 +302,6 @@ class Client implements RabbitContract
             );
 
             if (!($message->has('reply_to') && $message->has('correlation_id'))) {
-                info('3. it is not rpc', [$message->get_properties()]);
                 return $this;
             }
 

--- a/src/Rabbit/Client.php
+++ b/src/Rabbit/Client.php
@@ -300,31 +300,39 @@ class Client implements RabbitContract
                 data_get($data, 'method', 'default'),
                 array_merge(data_get($data, 'params', []), [config('amqp.device_parameter_name') => $this->extract('device', $message)])
             );
-
+        } catch (Throwable $exception) {
             if (!($message->has('reply_to') && $message->has('correlation_id'))) {
-                return $this;
+
+                DeadLetterHandler::toQueue($data, $exception, $this);
+            } else {
+                $result = [
+                    'success' => false,
+                    'message' => $exception->getMessage(),
+                ];
             }
+        }
 
-            $client = $this->viaRpc()
-                ->setChannel($message->getChannel())
-                ->setParams(['correlation_id' => $message->get('correlation_id')])
-                ->setMessage($result);
+        if (!($message->has('reply_to') && $message->has('correlation_id'))) {
+            return $this;
+        }
 
-            if ($this->isMultiQueue()) {
+        $client = $this->viaRpc()
+            ->setChannel($message->getChannel())
+            ->setParams(['correlation_id' => $message->get('correlation_id')])
+            ->setMessage($result);
 
-                $client = $client->disableMultiQueue()
-                    ->publish($message->get('reply_to'))
-                    ->enableMultiQueue();
+        if ($this->isMultiQueue()) {
 
-                return $client;
-            }
-
-            $client = $client->publish($message->get('reply_to'))->disableRpc();
+            $client = $client->disableMultiQueue()
+                ->publish($message->get('reply_to'))
+                ->enableMultiQueue();
 
             return $client;
-        } catch (Throwable $exception) {
-            throw new Exception($exception->getMessage() ? $exception->getMessage() : 'Unknown error');
         }
+
+        $client = $client->publish($message->get('reply_to'))->disableRpc();
+
+        return $client;
     }
 
     /**

--- a/src/Rabbit/MessageDispatcher.php
+++ b/src/Rabbit/MessageDispatcher.php
@@ -32,6 +32,7 @@ class MessageDispatcher
      * @param string $name
      * @param array $parameters
      * @return mixed|void
+     * @throws Exception
      */
     public function dispatch(string $name, array $parameters)
     {
@@ -59,11 +60,6 @@ class MessageDispatcher
             return [
                 'success' => false,
                 'message' => $validationException->errors()
-            ];
-        } catch (Throwable $exception) {
-            return [
-                'success' => false,
-                'message' => $exception->getMessage()
             ];
         }
     }

--- a/src/config/amqp.php
+++ b/src/config/amqp.php
@@ -38,4 +38,11 @@ return [
      * It will be merged to root namespace which is App/config('amqp.service_namespace')/config('amqp.dto_namespace')
      */
     'dto_namespace' => 'Dto',
+
+    /**
+     * When error is out in service class, that message will be sent to config('amqp.dead-letter-queue')
+     *
+     * This works only subscriber and publisher mode
+     */
+    'dead_letter_queue' => 'dead-letter-queue',
 ];


### PR DESCRIPTION
If you remember. We discussed about that issue few months ago. 

![image](https://github.com/sobirjonovs/laravel-rabbit/assets/63544323/746e517f-a7f4-43ce-b71d-a63499593e81)

I tried to solve it.